### PR TITLE
Handle header mismatches better; clean up more.

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -57,14 +57,6 @@ func mismatchHeaderFields(structInfo []fieldInfo, headers []string) []string {
 	return missing
 }
 
-func maybeMissingStructFields(structInfo []fieldInfo, headers []string) error {
-	missing := mismatchStructFields(structInfo, headers)
-	if len(missing) != 0 {
-		return fmt.Errorf("found unmatched struct field with tags %v", missing)
-	}
-	return nil
-}
-
 // Check that no header name is repeated twice
 func maybeDoubleHeaderNames(headers []string) error {
 	headerMap := make(map[string]bool, len(headers))


### PR DESCRIPTION
When allocating a new `Unmarshaller`, and some headers in the file don’t match the names in the output struct’s field tags, Commando has two behaviors:

1. The default: Continue on anyway.  Any non-matching fields are silently ignored.
2. When `Config.FailIfUnmatchedStructTags` is `true`: fail if there’s *any* mismatch between the headers and struct.

A non-obvious effect of 1 is that if a file is parsed into the wrong type of struct — that is, if the headers in the file don’t match *any* in the struct — Commando will silently produce a whole file’s worth of zero-value output structs.

This PR addresses that, by adding a check to `Config.validate()` which returns an error in that situation; and adds tests.

While I was adding this, I cleaned up two things:

- `mismatchedHeaders` and `mismatchedStructFields` have been removed from `validConfig`.  They weren’t used anywhere, because Commando validates everything once, up-front, instead of on every read like gocsv did.
- Handling of unmatched columns during unmarshalling has been removed, that is, `ReadUnmatched()` and the `map[string]string` return value from `unmarshalRow()`.  These were completely unused (for the reasons in the previous bullet point), but I hadn’t noticed.