### PR TITLE
Fix incorrect line numbers; improve error messages; update tests

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,11 +79,11 @@ func (c *Config) validate(headers []string) (*validConfig, error) {
 	}
 
 	return &validConfig{
-		Config:                 *c,
-		outType:                reflect.TypeOf(c.Holder),
-		headers:                headers,
-		structInfo:             structInfo,
-		fieldInfoMap:           csvHeadersLabels,
+		Config:       *c,
+		outType:      reflect.TypeOf(c.Holder),
+		headers:      headers,
+		structInfo:   structInfo,
+		fieldInfoMap: csvHeadersLabels,
 	}, nil
 }
 
@@ -97,6 +97,6 @@ type validConfig struct {
 	// headers is a slice of header names in file order.
 	headers []string
 
-	structInfo             *structInfo
-	fieldInfoMap           []*fieldInfo
+	structInfo   *structInfo
+	fieldInfoMap []*fieldInfo
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/evenco/commando
 
 go 1.13
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -68,7 +68,6 @@ func TestMarshaller_WriteAll(t *testing.T) {
 		{FieldA: "c", FieldB: "d"},
 		{FieldA: "A", FieldB: "B"}}
 
-
 	if err := m.WriteAll(s); err != nil {
 		t.Fatalf("Error calling WriteAll(): %#v", err)
 	}

--- a/reflect.go
+++ b/reflect.go
@@ -34,9 +34,9 @@ func (si *structInfo) headers() []string {
 // Each IndexChain element before the last is the index of an the embedded struct field
 // that defines Key as a tag
 type fieldInfo struct {
-	keys         []string
-	omitEmpty    bool
-	IndexChain   []int
+	keys       []string
+	omitEmpty  bool
+	IndexChain []int
 }
 
 func (f fieldInfo) getFirstKey() string {

--- a/sample_structs_test.go
+++ b/sample_structs_test.go
@@ -1,8 +1,9 @@
 package commando
 
 import (
+	"strconv"
 	"time"
-	"strconv")
+)
 
 type Sample struct {
 	Foo  string  `csv:"foo"`

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -49,10 +49,8 @@ func (um *Unmarshaller) Read() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	um.line++
 	out, err := um.unmarshalRow(row)
-	if err != nil {
-		um.line++
-	}
 	return out, wrapLine(err, um.line)
 }
 

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -36,7 +36,8 @@ func (c *Config) NewUnmarshaller(reader Reader) (*Unmarshaller, error) {
 	um := &Unmarshaller{
 		reader: reader,
 		config: vc,
-		line:   1,
+		// Start at L1 because reader.Read() was called for headers.
+		line: 1,
 	}
 
 	return um, nil

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -129,7 +129,7 @@ func (um *Unmarshaller) unmarshalRow(row []string) (interface{}, error) {
 		if j < len(um.config.fieldInfoMap) && um.config.fieldInfoMap[j] != nil {
 			fieldInfo := um.config.fieldInfoMap[j]
 			if err := setInnerField(&outValue, isPointer, fieldInfo.IndexChain, csvColumnContent, fieldInfo.omitEmpty); err != nil { // Set field of struct
-				return nil, fmt.Errorf("cannot assign field at %v to %T through index chain %v: %v", j, outValue, fieldInfo.IndexChain, err)
+				return nil, fmt.Errorf("cannot assign field %q at index %v through index chain %v: %v", um.config.headers[j], j, fieldInfo.IndexChain, err)
 			}
 		}
 	}

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -61,21 +61,20 @@ c,d,e
 }
 
 func Test_Read_ErrorLineNumbers(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
 	um, err := NewUnmarshaller(sample{}, csv.NewReader(strings.NewReader(brokenCSV)))
 	if err != nil {
 		t.Fatalf("Failed to allocate Unmarshaller: %s", err.Error())
 	}
 
-
 	// Lines 4 & 5 have errors.
 
 	var rec interface{}
 	// Header is line 1
-	_, err = um.Read()			// line 2
-	_, err = um.Read()			// line 3
-	_, err = um.Read()			// line 4
+	_, err = um.Read() // line 2
+	_, err = um.Read() // line 3
+	_, err = um.Read() // line 4
 
 	// Line 5 has the first error
 	rec, err = um.Read()
@@ -90,7 +89,7 @@ func Test_Read_ErrorLineNumbers(t *testing.T) {
 }
 
 func Test_ReadAll(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
 	ctx := context.Background()
 
@@ -158,7 +157,7 @@ func Test_ReadAll(t *testing.T) {
 }
 
 func Test_Unmarshaller_Allocation(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
 	exactHeaders := `field_a,field_b`
 	overlappingHeaders := `field_b,field_c`

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -3,9 +3,13 @@ package commando
 import (
 	"context"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,6 +21,7 @@ c,d
 	brokenCSV = csvContents + `e,f,g
 h,i,j
 k,l
+m,n,o
 `
 )
 
@@ -34,39 +39,25 @@ c,d,e
 	reader.FieldsPerRecord = -1
 	c := &Config{Holder: sample{}}
 	um, err := c.NewUnmarshaller(reader)
-	if err != nil {
-		t.Fatalf("Error calling NewUnmarshaller: %#v", err)
-	}
+	require.NoError(t, err)
 
 	obj, err := um.Read()
-	if err != nil {
-		t.Fatalf("Error calling Read(): %#v", err)
-	}
-	if obj.(sample).FieldA != "a" || obj.(sample).FieldB != "b" {
-		t.Fatalf("Unepxected result from Read(): %#v", obj)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, sample{"a", "b"}, obj, "Unexpected result from Read()")
 
 	obj, err = um.Read()
-	if err != nil {
-		t.Fatalf("Error calling Read(): %#v", err)
-	}
-	if obj.(sample).FieldA != "c" || obj.(sample).FieldB != "d" {
-		t.Fatalf("Unepxected result from Read(): %#v", obj)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, sample{"c", "d"}, obj, "Unexpected result from Read()")
 
 	obj, err = um.Read()
-	if err != io.EOF {
-		t.Fatalf("Unepxected result from Read(): (%#v, %#v)", obj, err)
-	}
+	require.Equal(t, io.EOF, err, "Expected io.EOF")
 }
 
 func Test_Read_ErrorLineNumbers(t *testing.T) {
 	t.Parallel()
 
 	um, err := NewUnmarshaller(sample{}, csv.NewReader(strings.NewReader(brokenCSV)))
-	if err != nil {
-		t.Fatalf("Failed to allocate Unmarshaller: %s", err.Error())
-	}
+	require.NoError(t, err)
 
 	// Lines 4 & 5 have errors.
 
@@ -74,18 +65,80 @@ func Test_Read_ErrorLineNumbers(t *testing.T) {
 	// Header is line 1
 	_, err = um.Read() // line 2
 	_, err = um.Read() // line 3
-	_, err = um.Read() // line 4
 
-	// Line 5 has the first error
+	// Line 4 has the first error
 	rec, err = um.Read()
-	if err == nil {
-		t.Fatal("Expected error")
-	} else if strings.Index(err.Error(), "line 5") == -1 {
-		t.Fatal("Expected the error to mention line 5")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 4", "Expected the error to mention line number")
+	assert.Nil(t, rec, "Expected no record")
+
+	// Line 5 is also broken
+	rec, err = um.Read()
+	require.Error(t, err, "Expected error")
+	assert.Contains(t, err.Error(), "line 5", "Expected the error to mention line number")
+	assert.Nil(t, rec, "Expected no record")
+
+	// Line 6 is good
+	rec, err = um.Read()
+	require.NoError(t, err, "Expected no error")
+	require.Equal(t, sample{"k", "l"}, rec)
+
+	// Line 7 is broken again
+	rec, err = um.Read()
+	require.Error(t, err, "Expected error")
+	assert.Contains(t, err.Error(), "line 7", "Expected the error to mention line number")
+	assert.Nil(t, rec, "Expected no record")
+}
+
+func Test_ReadAll_ErrorLineNumbers(t *testing.T) {
+	t.Parallel()
+
+	type sample2 struct {
+		A float64 `csv:"a"`
+		B string  `csv:"b"`
 	}
-	if rec != nil {
-		t.Fatal("Expected no record")
+
+	brokenCSV := `a,b
+1.0,a
+2.0-,b
+3.3,c
+`
+
+	ctx := context.Background()
+	um, err := NewUnmarshaller(sample2{}, csv.NewReader(strings.NewReader(brokenCSV)))
+	require.NoError(t, err, "Failed to allocate Unmarshaller")
+
+	_, err = um.ReadAll(ctx, StopOnError)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "line 3", "Expected the error to mention line number")
+}
+
+func Test_ReadAll_LogErrorLineNumbers(t *testing.T) {
+	t.Parallel()
+
+	var errs []error
+	logError := func(_ context.Context, err error) error {
+		errs = append(errs, err)
+		return nil
 	}
+
+	ctx := context.Background()
+	um, err := NewUnmarshaller(sample{}, csv.NewReader(strings.NewReader(brokenCSV)))
+	require.NoError(t, err)
+
+	out, err := um.ReadAll(ctx, logError)
+	require.NoError(t, err)
+	expected := []sample{
+		{"a", "b"},
+		{"c", "d"},
+		{"k", "l"},
+	}
+	require.Equal(t, expected, out)
+
+	assert.Len(t, errs, 3)
+	assert.Contains(t, errs[0].Error(), "line 4")
+	assert.Contains(t, errs[1].Error(), "line 5")
+	assert.Contains(t, errs[2].Error(), "line 7")
 }
 
 func Test_ReadAll(t *testing.T) {
@@ -94,41 +147,30 @@ func Test_ReadAll(t *testing.T) {
 	ctx := context.Background()
 
 	um, err := NewUnmarshaller(sample{}, csv.NewReader(strings.NewReader(csvContents)))
-	if err != nil {
-		t.Fatalf("Failed to allocate Unmarshaller: %s", err.Error())
-	}
+	require.NoError(t, err)
 
 	out, err := um.ReadAll(ctx, StopOnError)
-	if err != nil {
-		t.Fatalf("Failed to ReadAll(): %s", err.Error())
-	}
+	require.NoError(t, err)
+
 	switch samples := out.(type) {
 	case []sample:
-		if len(samples) != 2 {
-			t.Fatalf("Expected length 2, but got: %v", samples)
-		}
+		assert.Len(t, samples, 2)
 	default:
-		t.Fatalf("Expected []sample, but got %T", out)
+		assert.Fail(t, fmt.Sprintf("Expected []sample, but got %T", out))
 	}
 
 	// With pointers
 
 	um, err = NewUnmarshaller(&sample{}, csv.NewReader(strings.NewReader(csvContents)))
-	if err != nil {
-		t.Fatalf("Failed to allocate Unmarshaller: %s", err.Error())
-	}
+	require.NoError(t, err)
 
 	out, err = um.ReadAll(ctx, StopOnError)
-	if err != nil {
-		t.Fatalf("Failed to allocate ReadAll(): %s", err.Error())
-	}
+	require.NoError(t, err)
 	switch samples := out.(type) {
 	case []*sample:
-		if len(samples) != 2 {
-			t.Fatalf("Expected length 2, but got: %v", samples)
-		}
+		assert.Len(t, samples, 2)
 	default:
-		t.Fatalf("Expected []sample, but got %T", out)
+		assert.Fail(t, fmt.Sprintf("Expected []sample, but got %T", out))
 	}
 
 	// Handling errors
@@ -138,21 +180,15 @@ func Test_ReadAll(t *testing.T) {
 	}
 
 	um, err = NewUnmarshaller(&sample{}, csv.NewReader(strings.NewReader(brokenCSV)))
-	if err != nil {
-		t.Fatalf("Failed to allocate Unmarshaller: %s", err.Error())
-	}
+	require.NoError(t, err)
 
 	out, err = um.ReadAll(ctx, ignoreErrors)
-	if err != nil {
-		t.Fatalf("Failed to allocate ReadAll(): %s", err.Error())
-	}
+	require.NoError(t, err)
 	switch samples := out.(type) {
 	case []*sample:
-		if len(samples) != 3 {
-			t.Fatalf("Expected length 2, but got: %v", samples)
-		}
+		assert.Len(t, samples, 3)
 	default:
-		t.Fatalf("Expected []sample, but got %T", out)
+		assert.Fail(t, fmt.Sprintf("Expected []sample, but got %T", out))
 	}
 }
 
@@ -171,62 +207,38 @@ func Test_Unmarshaller_Allocation(t *testing.T) {
 
 	// An Unmarshaller should be returned if the file headers match the struct.
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(exactHeaders)))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if um == nil {
-		t.Fatal("Expected Unmarshaller")
-	}
+	require.NoError(t, err, "Unexpected error")
+	require.NotNil(t, um, "Expected Unmarshaller")
 
 	// Same behavior if FailIfUnmatchedStructTags is set.
 	config.FailIfUnmatchedStructTags = true
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(exactHeaders)))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if um == nil {
-		t.Fatal("Expected Unmarshaller")
-	}
+	require.NoError(t, err, "Unexpected error")
+	require.NotNil(t, um, "Expected Unmarshaller")
 
 	// An Unmarshaller should be returned if a *subset* of the file
 	// headers match the struct, and FailIfUnmatchedStructTags = false
 	config.FailIfUnmatchedStructTags = false
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(overlappingHeaders)))
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if um == nil {
-		t.Fatal("Expected Unmarshaller")
-	}
+	require.NoError(t, err, "Unexpected error")
+	require.NotNil(t, um, "Expected Unmarshaller")
 
 	// An error should be returned if *any* fields don't match and
 	// FailIfUnmatchedStructTags = true.
 	config.FailIfUnmatchedStructTags = true
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(overlappingHeaders)))
-	if err == nil {
-		t.Fatal("Expected error")
-	}
-	if um != nil {
-		t.Fatal("Expected no Unmarshaller")
-	}
+	require.Error(t, err, "Expected error")
+	require.Nil(t, um, "Expected no Unmarshaller")
 
 	// An error should be returned if none of the file headers match
 	// the struct, no matter what FailIfUnmatchedStructTags is set to
 	config.FailIfUnmatchedStructTags = false
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(disjointHeaders)))
-	if err == nil {
-		t.Fatalf("Expected error")
-	}
-	if um != nil {
-		t.Fatal("Expected no Unmarshaller")
-	}
+	require.Error(t, err, "Expected error")
+	require.Nil(t, um, "Expected no Unmarshaller")
 
 	config.FailIfUnmatchedStructTags = true
 	um, err = config.NewUnmarshaller(csv.NewReader(strings.NewReader(disjointHeaders)))
-	if err == nil {
-		t.Fatalf("Expected error")
-	}
-	if um != nil {
-		t.Fatal("Expected no Unmarshaller")
-	}
+	require.Error(t, err, "Expected error")
+	require.Nil(t, um, "Expected no Unmarshaller")
 }

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -64,7 +64,9 @@ func Test_Read_ErrorLineNumbers(t *testing.T) {
 	var rec interface{}
 	// Header is line 1
 	_, err = um.Read() // line 2
+	assert.NoError(t, err)
 	_, err = um.Read() // line 3
+	assert.NoError(t, err)
 
 	// Line 4 has the first error
 	rec, err = um.Read()


### PR DESCRIPTION
This PR addresses several things:

- It corrects some wrong line number reporting.  There were bugs in the existing tests as well as the code.
- Tests have been updated to use Testify, since it's way less hassle than a bajillion if-else-`t.Fatalf()` blocks.
- Error messages are improved, they include the column name instead of just the numeric index.
- Errors also don't include useless `reflect.Value` type info.
- All the code has been prettyprinted.