### PR TITLE
Fix incorrect handling of type aliases over slices in `WriteAll()`.

### DIFF
--- a/marshaller.go
+++ b/marshaller.go
@@ -72,8 +72,8 @@ func (m *Marshaller) WriteAll(values interface{}) error {
 		v = v.Elem()
 	}
 
-	if v.Type() != reflect.SliceOf(m.config.outType) {
-		return fmt.Errorf("Expected []%T, but got %T", m.config.outType, values)
+	if v.Kind() != reflect.Slice && reflect.TypeOf(v.Elem()) != m.config.outType {
+		return fmt.Errorf("Expected []%s, but got %T", m.config.outType, values)
 	}
 
 	n := v.Len()

--- a/marshaller_test.go
+++ b/marshaller_test.go
@@ -1,9 +1,9 @@
 package commando
 
 import (
+	"bytes"
 	"encoding/csv"
 	"testing"
-	"bytes"
 )
 
 func TestMarshaller(t *testing.T) {
@@ -58,12 +58,56 @@ func TestMarshaller_WriteAll(t *testing.T) {
 	}
 
 	// Make sure a type error is returned
-	ws := []int{1, 2,3}
+	ws := []int{1, 2, 3}
 	if err := m.WriteAll(ws); err == nil {
 		t.Fatalf("Expected a type error")
 	}
 
 	s := []sample{
+		{FieldA: "a", FieldB: "b"},
+		{FieldA: "c", FieldB: "d"},
+		{FieldA: "A", FieldB: "B"}}
+
+	if err := m.WriteAll(s); err != nil {
+		t.Fatalf("Error calling WriteAll(): %#v", err)
+	}
+	m.Flush()
+
+	csv := out.String()
+	expected := `field_a,field_b
+a,b
+c,d
+A,B
+`
+	if csv != expected {
+		t.Fatalf("Got unexpected CSV output:\n%q\n", csv)
+	}
+}
+
+func TestMarshaller_WriteAll_SliceAliass(t *testing.T) {
+	t.Parallel()
+
+	type sample struct {
+		FieldA string `csv:"field_a"`
+		FieldB string `csv:"field_b"`
+	}
+
+	type samples []sample
+
+	out := new(bytes.Buffer)
+
+	m, err := NewMarshaller(sample{}, csv.NewWriter(out))
+	if err != nil {
+		t.Fatalf("Error calling NewMarshaller: %#v", err)
+	}
+
+	// Make sure a type error is returned
+	ws := []int{1, 2, 3}
+	if err := m.WriteAll(ws); err == nil {
+		t.Fatalf("Expected a type error")
+	}
+
+	s := samples{
 		{FieldA: "a", FieldB: "b"},
 		{FieldA: "c", FieldB: "d"},
 		{FieldA: "A", FieldB: "B"}}


### PR DESCRIPTION
If you create a new type definition:

    type Blahs []Blah

And passed a `Blahs` into `WriteAll()`, it would blow up, because,
though `Blahs` is a `[]Blah`, its type isn’t equal to:

    reflect.SliceOf(reflect.TypeOf(Blah{}))

Even though its `Kind` is `Slice`, and its `Elem` is `Blah`.